### PR TITLE
:bug: Format string conflates dates/minutes

### DIFF
--- a/lib/report/index.html.ejs
+++ b/lib/report/index.html.ejs
@@ -190,7 +190,7 @@ editor.gotoLine(1);editor.setHighlightActiveLine(false);
 
 var l = _;
 
-$('#timestamp').html(moment(Report.aggregate.timestamp).format('DD MMM YYYY HH:MM:SS'));
+$('#timestamp').html(moment(Report.aggregate.timestamp).format('DD MMM YYYY HH:mm:SS'));
 $('#testDuration').html(l.size(Report.intermediate) * 10);
 $('#scenariosCompleted').html(Report.aggregate.scenariosCompleted);
 $('#scenariosCreated').html(Report.aggregate.scenariosCreated);


### PR DESCRIPTION
MM is a two digit month representation (e.g. August -> "08"), whereas mm
is a two digit minute representation.